### PR TITLE
Add L2 Gas Estimation to Bundler

### DIFF
--- a/packages/bundler/localconfig/bundler.config.json
+++ b/packages/bundler/localconfig/bundler.config.json
@@ -6,7 +6,7 @@
   "beneficiary": "0xd21934eD8eAf27a67f0A70042Af50A1D6d195E81",
   "minBalance": "1",
   "mnemonic": "./localconfig/mnemonic.txt",
-  "maxBundleGas": 5e6,
+  "maxBundleGas": 10e6,
   "minStake": "1" ,
   "minUnstakeDelay": 0 ,
   "autoBundleInterval": 3,

--- a/packages/bundler/src/UserOpMethodHandler.ts
+++ b/packages/bundler/src/UserOpMethodHandler.ts
@@ -162,7 +162,7 @@ export class UserOpMethodHandler {
 
     // In this method, we use a `L1GasLimit` concept to compensate bundler
     // with the Gas this transaction would consume when going to L1, and
-    // add it to `preVerificationGas` such that User's of this method can
+    // add it to `preVerificationGas` such that the User of this method can
     // simiply use the returned `preVerificationGas` in their
     // UserOperation without further calculation.
     const L1GasLimit = await getExtraL1Gas(this.provider, userOp)

--- a/packages/bundler/src/UserOpMethodHandler.ts
+++ b/packages/bundler/src/UserOpMethodHandler.ts
@@ -9,10 +9,13 @@ import { UserOperationEventEvent } from '@account-abstraction/contracts/dist/typ
 import { calcPreVerificationGas } from '@account-abstraction/sdk'
 import { requireCond, RpcError, tostr } from './utils'
 import { ExecutionManager } from './modules/ExecutionManager'
-import { getAddr } from './modules/moduleUtils'
+import { getAddr, getExtraL1Gas } from './modules/moduleUtils'
 import { UserOperationByHashResponse, UserOperationReceipt } from './RpcTypes'
 import { ExecutionErrors, UserOperation, ValidationErrors } from './modules/Types'
 
+import Debug from 'debug'
+
+const debugGas = Debug('aa.gas')
 const HEX_REGEX = /^0x[a-fA-F\d]*$/i
 
 /**
@@ -143,7 +146,33 @@ export class UserOpMethodHandler {
     if (validAfter === BigNumber.from(0)) {
       validAfter = undefined
     }
-    const preVerificationGas = calcPreVerificationGas(userOp)
+
+    // Gas adjustment in L2 (Arbitrum) network
+    //
+    // For a transactions in layer 2 network, the Gas estimation is less
+    // straightforward than in L1, and the calculation may vary in networks.
+    // However, conceptual wise we can view the total Gas consumption as
+    // two parts: (1) L2 Gas + (2) L1 Gas. The L2 Gas account for executing
+    // the transaction in L2 network, the L1 Gas account for syncing this
+    // transaction's data to L1.
+    //
+    // We can only estimate the gas consumtion in L2, we have to rely on
+    // tools provided by L2 network to esitmate the corresponding L1 cost
+    // for a transaction.
+
+    // In this method, we use a `L1GasLimit` concept to compensate bundler
+    // with the Gas this transaction would consume when going to L1, and
+    // add it to `preVerificationGas` such that User's of this method can
+    // simiply use the returned `preVerificationGas` in their
+    // UserOperation without further calculation.
+    const L1GasLimit = await getExtraL1Gas(this.provider, userOp)
+    let preVerificationGas = calcPreVerificationGas(userOp)
+    debugGas(`calcPreVerificationGas: ${preVerificationGas}`)
+    debugGas(`L1GasLimit: ${L1GasLimit}`)
+    debugGas(`Total Estimated Gas: ${preVerificationGas + callGasLimit + L1GasLimit}`)
+
+    preVerificationGas += BigNumber.from(L1GasLimit).mul(14).div(10).toNumber()
+    debugGas(`Required PreVerificationGas: ${preVerificationGas}`)
     const verificationGas = BigNumber.from(preOpGas).toNumber()
     return {
       preVerificationGas,

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -196,7 +196,7 @@ export class BundleManager {
         // Try to re-verify UserOp's profitability
         await this.validationManager.checkProfitability(entry.userOp)
       } catch (e: any) {
-        // Don't fail when it's profitable at this moment, wait until the network Gas fee goes down.
+        // Don't fail when it's not profitable at this moment, wait until the network Gas fee goes down.
         debug("userOp isn't profitable at this moment, leave it in the pool for now",
           entry.userOp.sender,
           entry.userOp.nonce)

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -164,6 +164,7 @@ export class BundleManager {
       const paymasterStatus = this.reputationManager.getStatus(paymaster)
       const deployerStatus = this.reputationManager.getStatus(factory)
       if (paymasterStatus === ReputationStatus.BANNED || deployerStatus === ReputationStatus.BANNED) {
+        debug('removing userOp for banned paymaster', entry.userOp.sender, entry.userOp.nonce)
         this.mempoolManager.removeUserOp(entry.userOp)
         continue
       }
@@ -190,12 +191,25 @@ export class BundleManager {
         this.mempoolManager.removeUserOp(entry.userOp)
         continue
       }
+
+      try {
+        // Try to re-verify UserOp's profitability
+        await this.validationManager.checkProfitability(entry.userOp)
+      } catch (e: any) {
+        // Don't fail when it's profitable at this moment, wait until the network Gas fee goes down.
+        debug("userOp isn't profitable at this moment, leave it in the pool for now",
+          entry.userOp.sender,
+          entry.userOp.nonce)
+        continue
+      }
+
       // todo: we take UserOp's callGasLimit, even though it will probably require less (but we don't
       // attempt to estimate it to check)
       // which means we could "cram" more UserOps into a bundle.
       const userOpGasCost = BigNumber.from(validationResult.returnInfo.preOpGas).add(entry.userOp.callGasLimit)
       const newTotalGas = totalGas.add(userOpGasCost)
       if (newTotalGas.gt(this.maxBundleGas)) {
+        debug(`skipping, exceeding bundler's maxBundleGas (${this.maxBundleGas})`)
         break
       }
 

--- a/packages/bundler/src/modules/ExecutionManager.ts
+++ b/packages/bundler/src/modules/ExecutionManager.ts
@@ -36,6 +36,7 @@ export class ExecutionManager {
       debug('sendUserOperation')
       this.validationManager.validateInputParameters(userOp, entryPointInput)
       const validationResult = await this.validationManager.validateUserOp(userOp, undefined)
+      await this.validationManager.checkProfitability(userOp)
       const userOpHash = await this.validationManager.entryPoint.getUserOpHash(userOp)
       this.mempoolManager.addUserOp(userOp,
         userOpHash,

--- a/packages/utils/src/ArbGasUtils.ts
+++ b/packages/utils/src/ArbGasUtils.ts
@@ -1,0 +1,420 @@
+import { BigNumber, ethers } from 'ethers'
+import { UserOperationStruct } from '@account-abstraction/contracts'
+import { Provider } from '@ethersproject/providers'
+
+export const ArbitrumEstimateGasHelperAddress = '0xf29afD09D63Cb38a23861e552D77a2E9bb15bE41'
+
+export const ArbitrumNodeInterfaceABI = [
+    {
+        inputs: [
+            {
+                internalType: 'uint64',
+                name: 'size',
+                type: 'uint64'
+            },
+            {
+                internalType: 'uint64',
+                name: 'leaf',
+                type: 'uint64'
+            }
+        ],
+        name: 'constructOutboxProof',
+        outputs: [
+            {
+                internalType: 'bytes32',
+                name: 'send',
+                type: 'bytes32'
+            },
+            {
+                internalType: 'bytes32',
+                name: 'root',
+                type: 'bytes32'
+            },
+            {
+                internalType: 'bytes32[]',
+                name: 'proof',
+                type: 'bytes32[]'
+            }
+        ],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'sender',
+                type: 'address'
+            },
+            {
+                internalType: 'uint256',
+                name: 'deposit',
+                type: 'uint256'
+            },
+            {
+                internalType: 'address',
+                name: 'to',
+                type: 'address'
+            },
+            {
+                internalType: 'uint256',
+                name: 'l2CallValue',
+                type: 'uint256'
+            },
+            {
+                internalType: 'address',
+                name: 'excessFeeRefundAddress',
+                type: 'address'
+            },
+            {
+                internalType: 'address',
+                name: 'callValueRefundAddress',
+                type: 'address'
+            },
+            {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes'
+            }
+        ],
+        name: 'estimateRetryableTicket',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint64',
+                name: 'blockNum',
+                type: 'uint64'
+            }
+        ],
+        name: 'findBatchContainingBlock',
+        outputs: [
+            {
+                internalType: 'uint64',
+                name: 'batch',
+                type: 'uint64'
+            }
+        ],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'to',
+                type: 'address'
+            },
+            {
+                internalType: 'bool',
+                name: 'contractCreation',
+                type: 'bool'
+            },
+            {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes'
+            }
+        ],
+        name: 'gasEstimateComponents',
+        outputs: [
+            {
+                internalType: 'uint64',
+                name: 'gasEstimate',
+                type: 'uint64'
+            },
+            {
+                internalType: 'uint64',
+                name: 'gasEstimateForL1',
+                type: 'uint64'
+            },
+            {
+                internalType: 'uint256',
+                name: 'baseFee',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint256',
+                name: 'l1BaseFeeEstimate',
+                type: 'uint256'
+            }
+        ],
+        stateMutability: 'payable',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'address',
+                name: 'to',
+                type: 'address'
+            },
+            {
+                internalType: 'bool',
+                name: 'contractCreation',
+                type: 'bool'
+            },
+            {
+                internalType: 'bytes',
+                name: 'data',
+                type: 'bytes'
+            }
+        ],
+        name: 'gasEstimateL1Component',
+        outputs: [
+            {
+                internalType: 'uint64',
+                name: 'gasEstimateForL1',
+                type: 'uint64'
+            },
+            {
+                internalType: 'uint256',
+                name: 'baseFee',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint256',
+                name: 'l1BaseFeeEstimate',
+                type: 'uint256'
+            }
+        ],
+        stateMutability: 'payable',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'bytes32',
+                name: 'blockHash',
+                type: 'bytes32'
+            }
+        ],
+        name: 'getL1Confirmations',
+        outputs: [
+            {
+                internalType: 'uint64',
+                name: 'confirmations',
+                type: 'uint64'
+            }
+        ],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [
+            {
+                internalType: 'uint256',
+                name: 'batchNum',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint64',
+                name: 'index',
+                type: 'uint64'
+            }
+        ],
+        name: 'legacyLookupMessageBatchProof',
+        outputs: [
+            {
+                internalType: 'bytes32[]',
+                name: 'proof',
+                type: 'bytes32[]'
+            },
+            {
+                internalType: 'uint256',
+                name: 'path',
+                type: 'uint256'
+            },
+            {
+                internalType: 'address',
+                name: 'l2Sender',
+                type: 'address'
+            },
+            {
+                internalType: 'address',
+                name: 'l1Dest',
+                type: 'address'
+            },
+            {
+                internalType: 'uint256',
+                name: 'l2Block',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint256',
+                name: 'l1Block',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint256',
+                name: 'timestamp',
+                type: 'uint256'
+            },
+            {
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256'
+            },
+            {
+                internalType: 'bytes',
+                name: 'calldataForL1',
+                type: 'bytes'
+            }
+        ],
+        stateMutability: 'view',
+        type: 'function'
+    },
+    {
+        inputs: [],
+        name: 'nitroGenesisBlock',
+        outputs: [
+            {
+                internalType: 'uint256',
+                name: 'number',
+                type: 'uint256'
+            }
+        ],
+        stateMutability: 'pure',
+        type: 'function'
+    }
+]
+
+const EstimateGasHelperABI: any =
+    [
+        {
+            inputs: [
+                {
+                    components: [
+                        {
+                            internalType: 'addr   ess',
+                            name: 'sender',
+                            type: 'address'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'nonce',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'bytes',
+                            name: 'initCode',
+                            type: 'bytes'
+                        },
+                        {
+                            internalType: 'bytes',
+                            name: 'callData',
+                            type: 'bytes'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'callGasLimit',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'verificationGasLimit',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'preVerificationGas',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'maxFeePerGas',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'uint256',
+                            name: 'maxPriorityFeePerGas',
+                            type: 'uint256'
+                        },
+                        {
+                            internalType: 'bytes',
+                            name: 'paymasterAndData',
+                            type: 'bytes'
+                        },
+                        {
+                            internalType: 'bytes',
+                            name: 'signature',
+                            type: 'bytes'
+                        }
+                    ],
+                    internalType: 'struct UserOperation',
+                    name: 'op',
+                    type: 'tuple'
+                }
+            ],
+            name: 'userOpCalldataTest',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function'
+        }
+    ]
+
+export interface IEstimateComponents {
+    baseFee: BigNumber
+    gasEstimate: BigNumber
+    gasEstimateForL1: BigNumber
+    l1BaseFeeEstimate: BigNumber
+}
+
+export class ArbitrumNodeInterface {
+    static arbitrumNodeInterface = '0x00000000000000000000000000000000000000C8'
+
+    public static async gasEstimateComponents (
+        etherProvider: Provider,
+        from: string | undefined,
+        to: string,
+        calldata: string, contractCreation = false
+    ): Promise<IEstimateComponents> {
+        const encodeABI = new ethers.utils.Interface(ArbitrumNodeInterfaceABI).encodeFunctionData('gasEstimateComponents', [
+            to,
+            contractCreation,
+            calldata
+        ])
+        const gasLimit = await etherProvider.call({
+            to: ArbitrumNodeInterface.arbitrumNodeInterface,
+            data: encodeABI,
+            from
+        })
+        const decodeABI = new ethers.utils.Interface(ArbitrumNodeInterfaceABI).decodeFunctionResult('gasEstimateComponents', gasLimit)
+
+        return {
+            baseFee: decodeABI.baseFee,
+            gasEstimate: decodeABI.gasEstimate,
+            gasEstimateForL1: decodeABI.gasEstimateForL1,
+            l1BaseFeeEstimate: decodeABI.l1BaseFeeEstimate
+        }
+    }
+}
+
+export class Arbitrum {
+    /**
+       * @static
+       * @param {Provider} l2Provider
+       * @param {UserOperationStruct} op
+       * @return {*}  {Promise<number>}
+       * @memberof Arbitrum
+       */
+    public static async L1GasLimit (
+        l2Provider: Provider,
+        op: UserOperationStruct
+    ): Promise<number> {
+        const data = new ethers.utils.Interface(EstimateGasHelperABI).encodeFunctionData('userOpCalldataTest', [op])
+        try {
+            const gasLimit = await ArbitrumNodeInterface.gasEstimateComponents(
+                l2Provider,
+                undefined,
+                ArbitrumEstimateGasHelperAddress,
+                data)
+            return gasLimit.gasEstimateForL1.toNumber()
+        } catch (error) {
+            throw error
+        }
+    }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Version'
 export * from './ERC4337Utils'
+export * from './ArbGasUtils'


### PR DESCRIPTION
Add L2 Gas Estimation when:
1. handling `estimateUserOperationGas`; the L2 Gas fee is added to the return preVerificationGas which should be updated the userOp.
2. handling `sendUserOperation`, bundler will make sure the preVerificationGas is set to a reasonable value such that bundler is at least profitable
3. bundling a userOp, bundler will check again the profitability of each userOp before adding it to a bundle, however due to the fact that L2 gas estimation can change quite frequently, bundle will not kick the userOp out of the mempool even when it find the userOp is not profitable any more at this moment, instead, it will keep it in the pool and hope the network Gas fee (mostly estimated L2 Gas) will drop some time later. 

Also change the `maxBundleGas` from `5e6` to `10e6`, a future PR will make this configurable.