### PR TITLE
Fix callGasLimit issue

### DIFF
--- a/packages/bundler/src/MetricRecorder.ts
+++ b/packages/bundler/src/MetricRecorder.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from 'ethers'
+import { deepHexlify } from '@account-abstraction/utils'
 import { SQS } from 'aws-sdk'
 import { UserOperation } from './modules/Types'
 import { getAwsSSMParameter } from './Config'
@@ -10,11 +12,13 @@ export interface IBundlerGasMetric {
   entryPoint: string
   userOp: UserOperation
   userOpHash: string
-  prefund: number
-  rtL1GasLimit: number
-  rtL2GasLimit: number
-  rtPreVerificationGas: number
-  actualGas: number
+  prefund: BigNumber
+  rtL1GasLimit: BigNumber
+  rtL2GasLimit: BigNumber
+  rtPreVerificationGas: BigNumber // expected preVerificationGas
+  rtPreVerificationGas1: BigNumber // calculated preVerificationGas
+  rtPreVerificationGas2: BigNumber // actual preVerificationGas
+  actualGas: BigNumber
   txHash: string
   submitTime: String
 }
@@ -37,7 +41,7 @@ export class MetricRecorder {
     }
 
     const messageParams = {
-      MessageBody: JSON.stringify(metric),
+      MessageBody: JSON.stringify(deepHexlify(metric)),
       QueueUrl: queueUrl
     }
 

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -1,6 +1,6 @@
 import { EntryPoint } from '@account-abstraction/contracts'
 import { MempoolManager } from './MempoolManager'
-import { ValidateUserOpResult, ValidationManager } from './ValidationManager'
+import { GasEstimateResult, ValidateUserOpResult, ValidationManager } from './ValidationManager'
 import { BigNumber, BigNumberish } from 'ethers'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 import Debug from 'debug'
@@ -197,23 +197,28 @@ export class BundleManager {
 
       try {
         // Try to re-verify UserOp's profitability
-        const { preVerificationGas, l1GasLimit, l2GasLimit } = await this.validationManager.checkProfitability(entry.userOp)
+        const gasEstimates = await this.validationManager.checkProfitability(entry.userOp)
         await this.metricRecorder.publish({
           chainId: this.provider._network.chainId,
           entryPoint: this.entryPoint.address,
           userOp: entry.userOp,
           userOpHash: entry.userOpHash,
-          prefund: BigNumber.from(entry.prefund).toNumber(),
-          rtL1GasLimit: l1GasLimit,
-          rtL2GasLimit: l2GasLimit,
-          rtPreVerificationGas: preVerificationGas,
+          prefund: BigNumber.from(entry.prefund),
+          rtL1GasLimit: gasEstimates.l1CallGasLimit,
+          rtL2GasLimit: gasEstimates.l2CallGasLimit,
+          rtPreVerificationGas: gasEstimates.expectedPreVerificationGas,
+          rtPreVerificationGas1: gasEstimates.calculatedPreVerificationGas,
+          rtPreVerificationGas2: gasEstimates.actualPreVerificationGas,
           submitTime: Date.now().toString()
+        }).catch((e: any) => {
+          console.warn('Failed to publish metrics', e)
         })
       } catch (e: any) {
         // Don't fail when it's not profitable at this moment, wait until the network Gas fee goes down.
         debug("userOp isn't profitable at this moment, leave it in the pool for now",
           entry.userOp.sender,
           entry.userOp.nonce)
+        console.warn(e)
         continue
       }
 

--- a/packages/bundler/src/modules/BundleManager.ts
+++ b/packages/bundler/src/modules/BundleManager.ts
@@ -1,6 +1,6 @@
 import { EntryPoint } from '@account-abstraction/contracts'
 import { MempoolManager } from './MempoolManager'
-import { GasEstimateResult, ValidateUserOpResult, ValidationManager } from './ValidationManager'
+import { ValidateUserOpResult, ValidationManager } from './ValidationManager'
 import { BigNumber, BigNumberish } from 'ethers'
 import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers'
 import Debug from 'debug'

--- a/packages/bundler/src/modules/moduleUtils.ts
+++ b/packages/bundler/src/modules/moduleUtils.ts
@@ -1,6 +1,6 @@
 // misc utilities for the various modules.
 
-import { BytesLike, ContractFactory } from 'ethers'
+import { BigNumber, BytesLike, ContractFactory } from 'ethers'
 import { hexlify, hexZeroPad, Result } from 'ethers/lib/utils'
 import { SlotMap, StorageMap, UserOperation } from './Types'
 import { Provider } from '@ethersproject/providers'
@@ -71,6 +71,25 @@ export async function runContractScript<T extends ContractFactory> (provider: Pr
   return parsed.args
 }
 
-export async function getArbGasLimits (provider: Provider, userOp: UserOperation): Promise<IArbGas> {
-  return await Arbitrum.EstimateGas(provider, userOp)
+/**
+ *
+ * @param provider provider to use for the call
+ * @param from the address of the entryPoint
+ * @param to the address of the sender
+ * @param data the calldata of the UserOperation
+ * @returns an object of IArbGas containing the callGasLimit for L1 and L2
+ */
+export async function getArbCallGasLimits (provider: Provider, from: string, to: string, data: BytesLike): Promise<IArbGas> {
+  return await Arbitrum.CallGasLimits(provider, from, to, data)
+}
+
+/**
+ *
+ * @param provider provider to use for the call
+ * @param userOp the UserOperation to get the LiGasLimit for
+ * @returns the L1GasLimit for the whole UserOperation. O if we are not on Arbitrum.
+ */
+export async function getArbL1GasLimit (provider: Provider, userOp: UserOperation): Promise<BigNumber> {
+  const l1GasLimit = await Arbitrum.L1GasLimit(provider, userOp)
+  return l1GasLimit ?? BigNumber.from(0)
 }


### PR DESCRIPTION
For `estimateUserOperationGas`, in Arbitrum, the `callGasLimit` should be the L2 portion of the total callGasLimit returned by `estimateGas`. The previous calculation wrongly used the whole userOp as input where we should only use `userOp.callData` as input when estimating the callGasLimit.

This PR mainly fixed this issue.
Also, some minor changes to MetricRecorder to include more fields.