### PR TITLE
Optimize bundler log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tsconfig.tsbuildinfo
 /packages/bundler/src/types/
 yarn-error.log
 .vscode
+.local

--- a/loadenv.sh
+++ b/loadenv.sh
@@ -1,0 +1,12 @@
+ENV=$1
+
+# Define the file name based on the input variable
+FILENAME=".local/${ENV}.env"
+
+# If the file exists, export all variables to the global shell
+if [ -f "$FILENAME" ]; then
+    echo "Loading ${ENV}.env"
+    export $(grep -v '^#' "$FILENAME" | xargs)
+else
+    echo "File ${FILENAME} does not exist."
+fi

--- a/packages/bundler/src/BundlerServer.ts
+++ b/packages/bundler/src/BundlerServer.ts
@@ -102,11 +102,12 @@ export class BundlerServer {
       jsonrpc,
       id
     } = req.body
-    debug('>>', { jsonrpc, id, method, params })
+    console.log('recv', method, '-', JSON.stringify(params, null, '') ?? '[]')
+    debug('>> %o', { jsonrpc, id, method, params })
     try {
       const result = deepHexlify(await this.handleMethod(method, params))
-      console.log('sent', method, '-', result)
-      debug('<<', { jsonrpc, id, result })
+      console.log('sent', method, '-', JSON.stringify(result, null, ''))
+      debug('<< %o', { jsonrpc, id, result })
       res.send({
         jsonrpc,
         id,
@@ -119,7 +120,7 @@ export class BundlerServer {
         code: err.code
       }
       console.log('failed: ', method, 'error:', JSON.stringify(error))
-      debug('<<', { jsonrpc, id, error })
+      debug('<< %o', { jsonrpc, id, error })
 
       res.send({
         jsonrpc,

--- a/packages/bundler/src/modules/ValidationManager.ts
+++ b/packages/bundler/src/modules/ValidationManager.ts
@@ -193,7 +193,7 @@ export class ValidationManager {
       l1CallGasLimit: l1GasLimit,
       l2CallGasLimit: l2GasLimit
     }
-    console.log(result)
+    console.log(`GasEstimateResult(${userOp.sender}, ${BigNumber.from(userOp.nonce).toHexString()}): ${JSON.stringify(result, null, '')}`)
     return result
   }
 


### PR DESCRIPTION
Prints RPC logs in one line. This would make tools parsing log much easier.